### PR TITLE
add a compatibilty mode for waterline adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ You may also supply an array of adapters and Offshore will map out the methods s
 
 #### Community Adapters
 
+  - [SQL](https://github.com/Atlantis-Software/offshore-sql)
+
+using waterline compatibility mode
+
+```javascript
+offshore.initialize({ compat: "waterline", ...
+```
+
   - [PostgreSQL](https://github.com/particlebanana/sails-postgresql) - *0.9+ compatible*
   - [MySQL](https://github.com/balderdashy/sails-mysql) - *0.9+ compatible*
   - [MongoDB](https://github.com/balderdashy/sails-mongo) - *0.9+ compatible*

--- a/lib/offshore.js
+++ b/lib/offshore.js
@@ -107,7 +107,9 @@ Offshore.prototype.initialize = function(options, cb) {
   function loadCollection(item, next) {
     var loader = new CollectionLoader(item, self.connections, defaults);
     var collection = loader.initialize(self);
-
+    if (options.compat) {
+      collection[options.compat] = self;
+    }
     // Store the instantiated collection so it can be used
     // internally to create other records
     self.collections[collection.identity.toLowerCase()] = collection;


### PR DESCRIPTION
some waterline adapters need this to work with offshore because they need to access "waterline" object
