### PR TITLE
add cache mechanism

### DIFF
--- a/lib/offshore.js
+++ b/lib/offshore.js
@@ -81,6 +81,10 @@ Offshore.prototype.initialize = function(options, cb) {
   if (!options.adapters) throw new Error('Options object must contain an adapters object');
   if (!options.connections) throw new Error('Options object must contain a connections object');
 
+  // configure cache
+  this.cache = require('./offshore/core/cache');
+  this.cache.initialize(options.cache);
+
   // Allow collections to be passed in to the initialize method
   if (options.collections) {
     for (var collection in options.collections) {

--- a/lib/offshore.js
+++ b/lib/offshore.js
@@ -81,10 +81,6 @@ Offshore.prototype.initialize = function(options, cb) {
   if (!options.adapters) throw new Error('Options object must contain an adapters object');
   if (!options.connections) throw new Error('Options object must contain a connections object');
 
-  // configure cache
-  this.cache = require('./offshore/core/cache');
-  this.cache.initialize(options.cache);
-
   // Allow collections to be passed in to the initialize method
   if (options.collections) {
     for (var collection in options.collections) {
@@ -121,7 +117,13 @@ Offshore.prototype.initialize = function(options, cb) {
     next();
   }
 
+  this.cache = require('./offshore/core/cache');
+
   async.auto({
+    // initialize cache
+    initializeCache: function(next) {
+      self.cache.initialize(options.cache, next);
+    },
 
     // Load all the collections into memory
     loadCollections: function(next) {

--- a/lib/offshore/core/cache.js
+++ b/lib/offshore/core/cache.js
@@ -1,0 +1,86 @@
+var fs = require('fs');
+var path = require('path');
+var os = require('os');
+var _ = require('lodash');
+
+var PATH = os.tmpdir();
+var PREFIX = 'CACHE_';
+var HEADER_SIZE = 20;
+var DEFAULT_CACHE_TIME = 3600000;
+
+function fullpath(key) {
+  return path.join(PATH, PREFIX + key);
+};
+
+module.exports = {
+  get: function(key,cb){
+    var self = this;
+    var headerStream = fs.createReadStream(fullpath(key), {start: 0, end: HEADER_SIZE - 1});
+    var header = '';
+    headerStream.on('error', function(err){
+      headerStream.destroy();
+      if (err.code === 'ENOENT') {
+        return cb(self.errors.NO_CACHE);
+      }
+      cb(err);
+    });
+    headerStream.on('data', function(data){
+      header += data.toString();
+    });
+    headerStream.on('end', function() {
+      var time = parseInt(header);
+      // if cache is valid
+      if ( time >= new Date().getTime() || time === 0) {
+        var content = '';
+        var contentStream = fs.createReadStream(fullpath(key), {start: HEADER_SIZE});
+        contentStream.on('error', function(err){
+          contentStream.destroy();
+          cb(err);
+        });
+        contentStream.on('data', function(data){
+          content += data.toString();
+        });
+        contentStream.on('end', function() {
+          var cache;
+          if (content === 'UNDEFINED') {
+            return cb(null);
+          }
+          try {
+            cache = JSON.parse(content);
+            cb(null,cache);
+          } catch(e) {
+            if (_.isUndefined(cache)) {
+              cb(e);
+            }
+          }
+        });
+      } else {
+        cb(self.errors.NO_CACHE);
+      }
+    });
+  },
+  set: function(key,value,time){
+    var valid = 0;
+    if (_.isUndefined(time)) {
+      valid = new Date().getTime() + DEFAULT_CACHE_TIME;
+    }
+    else if (time > 0) {
+      valid = new Date().getTime() + (time * 1000);
+    }
+    var content;
+    if (_.isUndefined(value)) {
+      content = 'UNDEFINED';
+    } else {
+      content = JSON.stringify(value);
+    }
+    var header = valid.toString();
+    var pad = HEADER_SIZE - header.length;
+    for (var i = 0; i < pad; i++) {
+      header += ' ';
+    }
+    fs.createWriteStream(fullpath(key)).write(header + content);
+  },
+  errors : {
+    NO_CACHE: new Error("NO_CACHE")
+  }
+};

--- a/lib/offshore/core/cache.js
+++ b/lib/offshore/core/cache.js
@@ -127,7 +127,7 @@ module.exports = {
                     return;
                   }
                   if (value.ttl >= new Date().getTime()) {
-                    cache.remove(key);
+                    cache.remove(key, function() {});
                   }
                 });
               }, time);

--- a/lib/offshore/core/cache.js
+++ b/lib/offshore/core/cache.js
@@ -3,16 +3,17 @@ var path = require('path');
 var os = require('os');
 var _ = require('lodash');
 
-var PATH = os.tmpdir();
-var PREFIX = 'CACHE_';
+var folder = os.tmpdir();
+var prefix = 'CACHE_';
+var defaultCacheTime = 3600000;
+
 var HEADER_SIZE = 20;
-var DEFAULT_CACHE_TIME = 3600000;
 
 function fullpath(key) {
-  return path.join(PATH, PREFIX + key);
+  return path.join(folder, prefix + key);
 };
 
-module.exports = {
+var DefaultAdapter = {
   get: function(key,cb){
     var self = this;
     var headerStream = fs.createReadStream(fullpath(key), {start: 0, end: HEADER_SIZE - 1});
@@ -62,7 +63,7 @@ module.exports = {
   set: function(key,value,time){
     var valid = 0;
     if (_.isUndefined(time)) {
-      valid = new Date().getTime() + DEFAULT_CACHE_TIME;
+      valid = new Date().getTime() + defaultCacheTime;
     }
     else if (time > 0) {
       valid = new Date().getTime() + (time * 1000);
@@ -79,6 +80,30 @@ module.exports = {
       header += ' ';
     }
     fs.createWriteStream(fullpath(key)).write(header + content);
+  }  
+};
+
+module.exports = {
+  initialize: function(options) {
+    var options = options || {};
+    options.defaultCacheTime = options.defaultCacheTime || defaultCacheTime;
+    
+    // if an adapter is specified
+    if (options.adapter && options.adapter !== 'default') {
+      // Detects if there is a `registerCache` in the adapter. Exit if it not exists.
+      if (!options.adapter.registerCache) {
+        throw new Error('Adapter does not support cache');
+      }
+      var cache = options.adapter.registerCache(options);
+      this.get = cache.get.bind(cache);
+      this.set = cache.set.bind(cache);
+    } else {
+      folder = options.folder || folder;
+      prefix = options.prefix || prefix;
+      defaultCacheTime = options.defaultCacheTime;
+      this.get = DefaultAdapter.get;
+      this.set = DefaultAdapter.set;
+    }
   },
   errors : {
     NO_CACHE: new Error("NO_CACHE")

--- a/lib/offshore/core/cache.js
+++ b/lib/offshore/core/cache.js
@@ -3,14 +3,14 @@ var path = require('path');
 var os = require('os');
 var _ = require('lodash');
 
-var folder = os.tmpdir();
+var filepath = os.tmpdir();
 var prefix = 'CACHE_';
 var defaultCacheTime = 3600000;
 
 var HEADER_SIZE = 20;
 
 function fullpath(key) {
-  return path.join(folder, prefix + key);
+  return path.join(filepath, prefix + key);
 };
 
 var DefaultAdapter = {
@@ -98,7 +98,7 @@ module.exports = {
       this.get = cache.get.bind(cache);
       this.set = cache.set.bind(cache);
     } else {
-      folder = options.folder || folder;
+      filepath = options.path || filepath;
       prefix = options.prefix || prefix;
       defaultCacheTime = options.defaultCacheTime;
       this.get = DefaultAdapter.get;

--- a/lib/offshore/core/cache.js
+++ b/lib/offshore/core/cache.js
@@ -11,34 +11,35 @@ var HEADER_SIZE = 20;
 
 function fullpath(key) {
   return path.join(filepath, prefix + key);
-};
+}
+;
 
 var DefaultAdapter = {
-  get: function(key,cb){
+  get: function(key, cb) {
     var self = this;
     var headerStream = fs.createReadStream(fullpath(key), {start: 0, end: HEADER_SIZE - 1});
     var header = '';
-    headerStream.on('error', function(err){
+    headerStream.on('error', function(err) {
       headerStream.destroy();
       if (err.code === 'ENOENT') {
         return cb(self.errors.NO_CACHE);
       }
       cb(err);
     });
-    headerStream.on('data', function(data){
+    headerStream.on('data', function(data) {
       header += data.toString();
     });
     headerStream.on('end', function() {
       var time = parseInt(header);
       // if cache is valid
-      if ( time >= new Date().getTime() || time === 0) {
+      if (time >= new Date().getTime() || time === 0) {
         var content = '';
         var contentStream = fs.createReadStream(fullpath(key), {start: HEADER_SIZE});
-        contentStream.on('error', function(err){
+        contentStream.on('error', function(err) {
           contentStream.destroy();
           cb(err);
         });
-        contentStream.on('data', function(data){
+        contentStream.on('data', function(data) {
           content += data.toString();
         });
         contentStream.on('end', function() {
@@ -48,8 +49,8 @@ var DefaultAdapter = {
           }
           try {
             cache = JSON.parse(content);
-            cb(null,cache);
-          } catch(e) {
+            cb(null, cache);
+          } catch (e) {
             if (_.isUndefined(cache)) {
               cb(e);
             }
@@ -60,7 +61,7 @@ var DefaultAdapter = {
       }
     });
   },
-  set: function(key,value,time){
+  set: function(key, value, time) {
     var valid = 0;
     if (_.isUndefined(time)) {
       valid = new Date().getTime() + defaultCacheTime;
@@ -76,36 +77,75 @@ var DefaultAdapter = {
     }
     var header = valid.toString();
     var pad = HEADER_SIZE - header.length;
-    for (var i = 0; i < pad; i++) {
+    for (var i = 0; i < pad; i ++) {
       header += ' ';
     }
     fs.createWriteStream(fullpath(key)).write(header + content);
-  }  
+  }
 };
 
 module.exports = {
-  initialize: function(options) {
+  initialize: function(options, cb) {
     var options = options || {};
+    var self = this;
     options.defaultCacheTime = options.defaultCacheTime || defaultCacheTime;
-    
+
     // if an adapter is specified
     if (options.adapter && options.adapter !== 'default') {
-      // Detects if there is a `registerCache` in the adapter. Exit if it not exists.
-      if (!options.adapter.registerCache) {
-        throw new Error('Adapter does not support cache');
+      // Detects if there is a `getDatastore` in the adapter. Exit if it not exists.
+      if (! options.adapter.getDatastore) {
+        throw new Error('Adapter does not support Datastore interface which is required for cache');
       }
-      var cache = options.adapter.registerCache(options);
-      this.get = cache.get.bind(cache);
-      this.set = cache.set.bind(cache);
+      options.adapter.getDatastore(options, function(err, cache) {
+        self.get = function(key, cb) {
+          cache.get(key, function(err, value) {
+            if (err && err.message === '404') {
+              cb(self.errors.NO_CACHE);
+            } else if (err) {
+              cb(err);
+            } else if (value.ttl >= new Date().getTime() || value.ttl === 0) {
+              cb(null, value.data);
+            } else {
+              cb(self.errors.NO_CACHE);
+            }
+          });
+        };
+        self.set = function(key, value, time) {
+          var valid = 0;
+          if (_.isUndefined(time)) {
+            valid = new Date().getTime() + defaultCacheTime;
+          } else if (time > 0) {
+            valid = new Date().getTime() + (time * 1000);
+          }
+          var data = {ttl: valid, data: value};
+          cache.set(key, data, function() {
+            if (time > 0) {
+              setTimeout(function() {
+                //check cache
+                cache.get(key, function(err, value) {
+                  if (err) {
+                    return;
+                  }
+                  if (value.ttl >= new Date().getTime()) {
+                    cache.remove(key);
+                  }
+                });
+              }, time);
+            }
+          });
+        };
+        cb();
+      });
     } else {
       filepath = options.path || filepath;
       prefix = options.prefix || prefix;
       defaultCacheTime = options.defaultCacheTime;
       this.get = DefaultAdapter.get;
       this.set = DefaultAdapter.set;
+      cb();
     }
   },
-  errors : {
+  errors: {
     NO_CACHE: new Error("NO_CACHE")
   }
 };

--- a/lib/offshore/query/criteria.js
+++ b/lib/offshore/query/criteria.js
@@ -1,0 +1,37 @@
+var _ = require('lodash');
+
+var Criteria = module.exports = {
+  toString: function(criteria) {
+    var self = this;
+    if (_.isUndefined(criteria)) {
+      return 'undefined';
+    }
+    if (_.isNull(criteria)) {
+      return 'null';
+    }
+    if (_.isString(criteria)) {
+      return criteria;
+    }
+    if (_.isNumber(criteria) || _.isDate(criteria) || _.isBoolean(criteria)) {
+      return criteria.toString();
+    }
+    if (_.isFunction(criteria)) {
+      return 'fct()';
+    }
+    if (_.isArray(criteria)) {
+      var arr = [];
+      criteria.forEach(function(crit) {
+        arr.push(self.toString(crit));
+      });
+      return '[' + _.sortBy(arr, function(ct) { return ct; }).toString() + ']';
+    }
+    if (_.isObject(criteria)) {
+      var keys = _.sortBy(_.keys(criteria), function(key) { return key; });
+      var ret = '{';
+      keys.forEach(function(key){
+        ret += "'" + key + "':" + self.toString(criteria[key]) + ',';
+      });
+      return ret.slice(0,-1) + '}';
+    }
+  }
+};

--- a/lib/offshore/query/deferred.js
+++ b/lib/offshore/query/deferred.js
@@ -14,6 +14,8 @@ var hasOwnProperty = utils.object.hasOwnProperty;
 var async = require('async');
 var DeepCursor = require('./deepCursor');
 var Cache = require('../core/cache');
+var Criteria = require('./criteria');
+var crypto = require('crypto');
 
 // Alias "catch" as "fail", for backwards compatibility with projects
 // that were created using Q
@@ -21,20 +23,62 @@ Promise.prototype.fail = Promise.prototype.catch;
 
 var Deferred = module.exports = function(context, method, criteria, values) {
 
-  if (!context) return new Error('Must supply a context to a new Deferred object. Usage: new Deferred(context, method, criteria)');
-  if (!method) return new Error('Must supply a method to a new Deferred object. Usage: new Deferred(context, method, criteria)');
+  if (!context)
+    return new Error('Must supply a context to a new Deferred object. Usage: new Deferred(context, method, criteria)');
+  if (!method)
+    return new Error('Must supply a method to a new Deferred object. Usage: new Deferred(context, method, criteria)');
 
   this._context = context;
   this._method = method;
+
+  // define the methodName
+  var methods = ['find', 'findOne', 'findOrCreate', 'createEach', 'findOrCreateEach', 'count', 'create', 'destroy', 'update', 'findAll'];
+  this._methodName = _.find(methods.concat(_.keys(context)), function(key) {
+    return context[key] === method;
+  }) || 'unknownMethod';
+
   this._criteria = criteria;
   this._values = values || null;
-  this._cacheKey = null;
 
   this._deferred = null; // deferred object for promises
 
   return this;
 };
 
+Deferred.prototype.toString = function() {
+  var criteria = Criteria.toString(this._criteria);
+  var str = this._context.identity + '.' + this._methodName + '(' + criteria + ')';
+
+  // check if there are deep populate
+  if (this._criteria.paths) {
+    var paths = _.sortBy(_.keys(this._criteria.paths), function(name) {
+      return name;
+    });
+    for (var path in paths) {
+      var joins = this._criteria.paths[path].joins;
+      // sort joins by alias
+      _.sortBy(joins, function(join) {
+        return join.alias;
+      }).forEach(function(join) {
+        if (!join.junctionTable) {
+          var joinCriteria = Criteria.toString(join.criteria);
+          str += '.populate(' + path + '.' + join.alias + ',' + joinCriteria + ')';
+        }
+      });
+    }
+  } else if (this._criteria.joins) {
+    // sort join by alias
+    _.sortBy(this._criteria.joins, function(join) {
+      return join.alias;
+    }).forEach(function(join) {
+      if (!join.junctionTable) {
+        var joinCriteria = Criteria.toString(join.criteria);
+        str += '.populate(' + join.alias + ',' + joinCriteria + ')';
+      }
+    });
+  }
+  return str;
+};
 
 /**
  * Add join clause(s) to the criteria object to populate
@@ -84,19 +128,65 @@ Deferred.prototype.populateAll = function(criteria) {
 };
 
 /**
- * Set _cacheKey and _cacheTime.
- *
- * Used to determine the cache of the request.
+ * Set _cacheKey and _cacheTime before execute the request.
  *
  * @param {String} key, the key to identify cache.
  * @param {Integer} time, the maximum time the cache must be used.
- * @return this
- * @chainable
+ * @param {Function} cb, callback
+ * @return callback with parameters (err, results)
  */
-Deferred.prototype.cache = function(key, time) {
-  this._cacheKey = key;
-  this._cacheTime = time || 0;
-  return this;
+Deferred.prototype.cache = function(key, time, cb) {
+  var self = this;
+  var callback, cacheKey, cacheTime;
+
+  if (this._methodName !== 'find' && this._methodName !== 'findOne') {
+    return cb(new Error(this._methodName + ' can not be cached'));
+  }
+
+  // define optional parameters
+  if (cb && _.isFunction(cb)) {
+    callback = cb;
+    cacheTime = time;
+    cacheKey = key;
+  } else if (time && _.isFunction(time)) {
+    callback = time;
+    cacheTime = key;
+  } else if (key && _.isFunction(key)) {
+    callback = key;
+  } else {
+    console.log(new Error('Error: No Callback supplied, you must define a callback.').message);
+    return;
+  }
+  cacheTime = cacheTime || 0;
+  cacheKey = cacheKey || crypto.createHash('sha1').update(this.toString()).digest('hex');
+
+  if (!_.isNumber(cacheTime)) {
+    throw new Error('Cache Time must be a number');
+  }
+
+  if (!_.isString(cacheKey)) {
+    throw new Error('Cache Key must be a string');
+  }
+  // Check cache
+  Cache.get(cacheKey, function(err, cache) {
+    if (err) {
+      // if no cache
+      if (err === Cache.errors.NO_CACHE) {
+        // execute the request and cache results
+        return self.exec(function(err, data) {
+          if (err) {
+            return callback(err);
+          }
+          Cache.set(cacheKey, data, cacheTime);
+          callback(null, data);
+        });
+      }
+      // return the error
+      return callback(err);
+    }
+    // cache found return its value
+    return callback(null, cache);
+  });
 };
 
 /**
@@ -141,7 +231,7 @@ Deferred.prototype.populate = function(keyName, criteria) {
       util.format('`.populate("%s")`', keyName) +
       '\nSub-criteria:\n' + util.inspect(criteria, false, null) +
       '\nDetails:\n' + util.inspect(e, false, null)
-    );
+      );
   }
 
   try {
@@ -160,7 +250,7 @@ Deferred.prototype.populate = function(keyName, criteria) {
       throw new Error(
         'In ' + util.format('`.populate("%s")`', keyName) +
         ', attempting to populate an attribute that doesn\'t exist'
-      );
+        );
     }
 
     //////////////////////////////////////////////////////////////////////
@@ -280,7 +370,7 @@ Deferred.prototype.populate = function(keyName, criteria) {
       util.format('`.populate("%s")`', keyName) +
       '\nDetails:\n' +
       util.inspect(e, false, null)
-    );
+      );
   }
 };
 
@@ -325,7 +415,7 @@ Deferred.prototype.populatePath = function(path, criteria) {
       throw new Error(
         'In ' + util.format('`.populate("%s")`', path) +
         ', attempting to populate an attribute that doesn\'t exist'
-      );
+        );
     }
     var childName = parentAttributes[currentAlias].model || parentAttributes[currentAlias].collection;
     if (!this._criteria.paths[currentPath]) {
@@ -374,10 +464,13 @@ Deferred.prototype.populatePath = function(path, criteria) {
 
 Deferred.prototype.where = function(criteria) {
 
-  if (!criteria) return this;
+  if (!criteria)
+    return this;
 
   // If the criteria is an array of objects, wrap it in an "or"
-  if (Array.isArray(criteria) && _.all(criteria, function(crit) {return _.isObject(crit);})) {
+  if (Array.isArray(criteria) && _.all(criteria, function(crit) {
+    return _.isObject(crit);
+  })) {
     criteria = {or: criteria};
   }
 
@@ -390,9 +483,11 @@ Deferred.prototype.where = function(criteria) {
     this._criteria = false;
   }
 
-  if (!criteria || !criteria.where) return this;
+  if (!criteria || !criteria.where)
+    return this;
 
-  if (!this._criteria) this._criteria = {};
+  if (!this._criteria)
+    this._criteria = {};
   var where = this._criteria.where || {};
 
   // Merge with existing WHERE clause
@@ -443,18 +538,21 @@ Deferred.prototype.skip = function(skip) {
 Deferred.prototype.paginate = function(options) {
   var defaultLimit = 10;
 
-  if (options === undefined) options = { page: 0, limit: defaultLimit };
+  if (options === undefined)
+    options = {page: 0, limit: defaultLimit};
 
   var page = options.page || 0;
   var limit = options.limit || defaultLimit;
   var skip = 0;
 
-  if (page > 0 && limit === 0) skip = page - 1;
-  if (page > 0 && limit > 0) skip = (page * limit) - limit;
+  if (page > 0 && limit === 0)
+    skip = page - 1;
+  if (page > 0 && limit > 0)
+    skip = (page * limit) - limit;
 
   this
-  .skip(skip)
-  .limit(limit);
+    .skip(skip)
+    .limit(limit);
 
   return this;
 };
@@ -480,10 +578,11 @@ Deferred.prototype.groupBy = function() {
 
 Deferred.prototype.sort = function(criteria) {
 
-  if (!criteria) return this;
+  if (!criteria)
+    return this;
 
   // Normalize criteria
-  criteria = normalize.criteria({ sort: criteria });
+  criteria = normalize.criteria({sort: criteria});
 
   var sort = this._criteria.sort || {};
 
@@ -573,33 +672,10 @@ Deferred.prototype.exec = function(cb) {
   // Normalize callback/switchback
   cb = normalize.callback(cb);
 
-  // Check cache
-  if (this._cacheKey !== null) {
-    Cache.get(this._cacheKey,function(err,cache){
-      
-      if (err) {
-        if (err !== Cache.errors.NO_CACHE) {
-          return cb(err);
-        }
-      } else {
-        return cb(null,cache);
-      }
-      var cacheKey = self._cacheKey;
-      self._cacheKey = null;
-      var callback = function(err,data){
-        if (!err) {
-          Cache.set(cacheKey, data, self._cacheTime);
-        }
-        cb(err,data);
-      };
-      self.exec(callback);
-    });
-    return;
-  }
-
   // Set up arguments + callback
   var args = [this._criteria, cb];
-  if (this._values) args.splice(1, 0, this._values);
+  if (this._values)
+    args.splice(1, 0, this._values);
 
   // Pass control to the adapter with the appropriate arguments.
   this._method.apply(this._context, args);
@@ -608,31 +684,7 @@ Deferred.prototype.exec = function(cb) {
 
 Deferred.prototype.execDeep = function(cb, cursor) {
   var self = this;
-  // Check cache
-  if (this._cacheKey !== null) {
-    Cache.get(this._cacheKey,function(err,cache){
-      
-      if (err) {
-        if (err !== Cache.errors.NO_CACHE) {
-          return cb(err);
-        }
-      } else {
-        return cb(null,cache);
-      }
-      var cacheKey = self._cacheKey;
-      self._cacheKey = null;
-      var callback = function(err,data){
-        if (!err) {
-          Cache.set(cacheKey, data, self._cacheTime);
-        }
-        cb(err,data);
-      };
-      self.execDeep(callback);
-    });
-    return;
-  }
-
-  // if true, first layer (path root)
+  // if this is the first layer (path root)
   if (!cursor) {
     cb = normalize.callback(cb);
 
@@ -669,7 +721,7 @@ Deferred.prototype.execDeep = function(cb, cursor) {
       } else {
         data = res.toJSON();
       }
-      cursor = new DeepCursor(self. _context.identity, data, self._criteria.paths);
+      cursor = new DeepCursor(self._context.identity, data, self._criteria.paths);
       self.execDeep(cb, cursor);
     });
 

--- a/lib/offshore/query/deferred.js
+++ b/lib/offshore/query/deferred.js
@@ -13,6 +13,7 @@ var acyclicTraversal = require('../utils/acyclicTraversal');
 var hasOwnProperty = utils.object.hasOwnProperty;
 var async = require('async');
 var DeepCursor = require('./deepCursor');
+var Cache = require('../core/cache');
 
 // Alias "catch" as "fail", for backwards compatibility with projects
 // that were created using Q
@@ -27,6 +28,7 @@ var Deferred = module.exports = function(context, method, criteria, values) {
   this._method = method;
   this._criteria = criteria;
   this._values = values || null;
+  this._cacheKey = null;
 
   this._deferred = null; // deferred object for promises
 
@@ -79,6 +81,22 @@ Deferred.prototype.populateAll = function(criteria) {
   });
   return this;
 
+};
+
+/**
+ * Set _cacheKey and _cacheTime.
+ *
+ * Used to determine the cache of the request.
+ *
+ * @param {String} key, the key to identify cache.
+ * @param {Integer} time, the maximum time the cache must be used.
+ * @return this
+ * @chainable
+ */
+Deferred.prototype.cache = function(key, time) {
+  this._cacheKey = key;
+  this._cacheTime = time || 0;
+  return this;
 };
 
 /**
@@ -550,9 +568,34 @@ Deferred.prototype.exec = function(cb) {
     console.log(new Error('Error: No Callback supplied, you must define a callback.').message);
     return;
   }
+  var self = this;
 
   // Normalize callback/switchback
   cb = normalize.callback(cb);
+
+  // Check cache
+  if (this._cacheKey !== null) {
+    Cache.get(this._cacheKey,function(err,cache){
+      
+      if (err) {
+        if (err !== Cache.errors.NO_CACHE) {
+          return cb(err);
+        }
+      } else {
+        return cb(null,cache);
+      }
+      var cacheKey = self._cacheKey;
+      self._cacheKey = null;
+      var callback = function(err,data){
+        if (!err) {
+          Cache.set(cacheKey, data, self._cacheTime);
+        }
+        cb(err,data);
+      };
+      self.exec(callback);
+    });
+    return;
+  }
 
   // Set up arguments + callback
   var args = [this._criteria, cb];
@@ -565,6 +608,30 @@ Deferred.prototype.exec = function(cb) {
 
 Deferred.prototype.execDeep = function(cb, cursor) {
   var self = this;
+  // Check cache
+  if (this._cacheKey !== null) {
+    Cache.get(this._cacheKey,function(err,cache){
+      
+      if (err) {
+        if (err !== Cache.errors.NO_CACHE) {
+          return cb(err);
+        }
+      } else {
+        return cb(null,cache);
+      }
+      var cacheKey = self._cacheKey;
+      self._cacheKey = null;
+      var callback = function(err,data){
+        if (!err) {
+          Cache.set(cacheKey, data, self._cacheTime);
+        }
+        cb(err,data);
+      };
+      self.execDeep(callback);
+    });
+    return;
+  }
+
   // if true, first layer (path root)
   if (!cursor) {
     cb = normalize.callback(cb);

--- a/lib/offshore/query/deferred.js
+++ b/lib/offshore/query/deferred.js
@@ -13,7 +13,6 @@ var acyclicTraversal = require('../utils/acyclicTraversal');
 var hasOwnProperty = utils.object.hasOwnProperty;
 var async = require('async');
 var DeepCursor = require('./deepCursor');
-var Cache = require('../core/cache');
 var Criteria = require('./criteria');
 var crypto = require('crypto');
 
@@ -23,10 +22,12 @@ Promise.prototype.fail = Promise.prototype.catch;
 
 var Deferred = module.exports = function(context, method, criteria, values) {
 
-  if (!context)
+  if (!context) {
     return new Error('Must supply a context to a new Deferred object. Usage: new Deferred(context, method, criteria)');
-  if (!method)
+  }
+  if (!method) {
     return new Error('Must supply a method to a new Deferred object. Usage: new Deferred(context, method, criteria)');
+  }
 
   this._context = context;
   this._method = method;
@@ -168,16 +169,16 @@ Deferred.prototype.cache = function(key, time, cb) {
     throw new Error('Cache Key must be a string');
   }
   // Check cache
-  Cache.get(cacheKey, function(err, cache) {
+  this._context.offshore.cache.get(cacheKey, function(err, cache) {
     if (err) {
       // if no cache
-      if (err === Cache.errors.NO_CACHE) {
+      if (err === self._context.offshore.cache.errors.NO_CACHE) {
         // execute the request and cache results
         return self.exec(function(err, data) {
           if (err) {
             return callback(err);
           }
-          Cache.set(cacheKey, data, cacheTime);
+          self._context.offshore.cache.set(cacheKey, data, cacheTime);
           callback(null, data);
         });
       }
@@ -250,7 +251,7 @@ Deferred.prototype.populate = function(keyName, criteria) {
       throw new Error(
         'In ' + util.format('`.populate("%s")`', keyName) +
         ', attempting to populate an attribute that doesn\'t exist'
-        );
+      );
     }
 
     //////////////////////////////////////////////////////////////////////
@@ -370,7 +371,7 @@ Deferred.prototype.populate = function(keyName, criteria) {
       util.format('`.populate("%s")`', keyName) +
       '\nDetails:\n' +
       util.inspect(e, false, null)
-      );
+    );
   }
 };
 
@@ -415,7 +416,7 @@ Deferred.prototype.populatePath = function(path, criteria) {
       throw new Error(
         'In ' + util.format('`.populate("%s")`', path) +
         ', attempting to populate an attribute that doesn\'t exist'
-        );
+      );
     }
     var childName = parentAttributes[currentAlias].model || parentAttributes[currentAlias].collection;
     if (!this._criteria.paths[currentPath]) {
@@ -464,13 +465,12 @@ Deferred.prototype.populatePath = function(path, criteria) {
 
 Deferred.prototype.where = function(criteria) {
 
-  if (!criteria)
+  if (!criteria) {
     return this;
+  }
 
   // If the criteria is an array of objects, wrap it in an "or"
-  if (Array.isArray(criteria) && _.all(criteria, function(crit) {
-    return _.isObject(crit);
-  })) {
+  if (Array.isArray(criteria) && _.all(criteria, function(crit) { return _.isObject(crit); })) {
     criteria = {or: criteria};
   }
 
@@ -483,11 +483,13 @@ Deferred.prototype.where = function(criteria) {
     this._criteria = false;
   }
 
-  if (!criteria || !criteria.where)
+  if (!criteria || !criteria.where) {
     return this;
+  }
 
-  if (!this._criteria)
+  if (!this._criteria) {
     this._criteria = {};
+  }
   var where = this._criteria.where || {};
 
   // Merge with existing WHERE clause
@@ -538,21 +540,22 @@ Deferred.prototype.skip = function(skip) {
 Deferred.prototype.paginate = function(options) {
   var defaultLimit = 10;
 
-  if (options === undefined)
+  if (_.isUndefined(options)) {
     options = {page: 0, limit: defaultLimit};
+  }
 
   var page = options.page || 0;
   var limit = options.limit || defaultLimit;
   var skip = 0;
 
-  if (page > 0 && limit === 0)
+  if (page > 0 && limit === 0) {
     skip = page - 1;
-  if (page > 0 && limit > 0)
+  }
+  if (page > 0 && limit > 0) {
     skip = (page * limit) - limit;
+  }
 
-  this
-    .skip(skip)
-    .limit(limit);
+  this.skip(skip).limit(limit);
 
   return this;
 };
@@ -667,15 +670,15 @@ Deferred.prototype.exec = function(cb) {
     console.log(new Error('Error: No Callback supplied, you must define a callback.').message);
     return;
   }
-  var self = this;
 
   // Normalize callback/switchback
   cb = normalize.callback(cb);
 
   // Set up arguments + callback
   var args = [this._criteria, cb];
-  if (this._values)
+  if (this._values) {
     args.splice(1, 0, this._values);
+  }
 
   // Pass control to the adapter with the appropriate arguments.
   this._method.apply(this._context, args);

--- a/lib/offshore/query/deferred.js
+++ b/lib/offshore/query/deferred.js
@@ -158,10 +158,10 @@ Deferred.prototype.cache = function(key, time, cb) {
     console.log(new Error('Error: No Callback supplied, you must define a callback.').message);
     return;
   }
-  cacheTime = cacheTime || 0;
+  
   cacheKey = cacheKey || crypto.createHash('sha1').update(this.toString()).digest('hex');
 
-  if (!_.isNumber(cacheTime)) {
+  if (cacheTime && !_.isNumber(cacheTime)) {
     throw new Error('Cache Time must be a number');
   }
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "eslint-nibble": "^0.1.1",
     "istanbul": "~0.3.14",
     "should": "~6.0.3",
-    "offshore-memory": "~0.0.3",
+    "offshore-memory": "~0.0.5",
     "offshore-adapter-tests": "~0.0.3",
     "mocha": "~2.2.5"
   },

--- a/test/unit/query/query.cache.js
+++ b/test/unit/query/query.cache.js
@@ -1,0 +1,63 @@
+var Offshore = require('../../../lib/offshore'),
+    assert = require('assert');
+
+describe('Collection Query', function() {
+
+  describe('.cache()', function() {
+    var query;
+
+    before(function(done) {
+
+      var offshore = new Offshore();
+      var Model = Offshore.Collection.extend({
+        identity: 'user',
+        connection: 'foo',
+        attributes: {
+          name: {
+            type: 'string',
+            defaultsTo: 'Foo Bar'
+          },
+          doSomething: function() {}
+        }
+      });
+
+      offshore.loadCollection(Model);
+
+      var first = true;
+      // Fixture Adapter Def
+      var adapterDef = { 
+        find: function(con, col, criteria, cb) {
+          if (!first) {
+            return cb(new Error('should not call adapter.find a second time'));
+          }
+          first = false;
+          return cb(null, [{name: 'should be cached'}]);
+        }
+      };
+
+      var connections = {
+        'foo': {
+          adapter: 'foobar'
+        }
+      };
+
+      offshore.initialize({ adapters: { foobar: adapterDef }, connections: connections }, function(err, colls) {
+        if(err) return done(err);
+        query = colls.collections.user;
+        done();
+      });
+    });
+
+    it('should cache results', function(done) {
+      query.find({}).cache('cache_test',10).exec(function(err, first_values) {
+        assert(!err);
+        query.find({}).cache('cache_test',10).exec(function(err, cached_values) {
+          assert(!err);
+          assert(first_values[0].name === cached_values[0].name);
+          done();
+        });
+      });
+    });
+
+  });
+});

--- a/test/unit/query/query.cache.js
+++ b/test/unit/query/query.cache.js
@@ -1,82 +1,163 @@
-var Offshore = require('../../../lib/offshore'),
-    assert = require('assert');
+var Offshore = require('../../../lib/offshore');
+var assert = require('assert');
 
 describe('Collection Query', function() {
 
   describe('.cache()', function() {
-    var query;
 
-    before(function(done) {
+    describe('default filesystem cache', function() {
+      var query;
 
-      var offshore = new Offshore();
-      var Model = Offshore.Collection.extend({
-        identity: 'random',
-        connection: 'foo',
-        attributes: {
-          number: {
-            type: 'integer',
-            defaultsTo: 1
-          },
-          doSomething: function() {}
-        }
-      });
+      before(function(done) {
 
-      offshore.loadCollection(Model);
+        var offshore = new Offshore();
+        var Model = Offshore.Collection.extend({
+          identity: 'random',
+          connection: 'foo',
+          attributes: {
+            number: {
+              type: 'integer',
+              defaultsTo: 1
+            },
+            doSomething: function() {
+            }
+          }
+        });
 
-      // Fixture Adapter Def
-      var adapterDef = { 
-        find: function(con, col, criteria, cb) {
-          return cb(null, [{number: Math.random() * 10000000000000000}]);
-        }
-      };
+        offshore.loadCollection(Model);
 
-      var connections = {
-        'foo': {
-          adapter: 'foobar'
-        }
-      };
+        // Fixture Adapter Def
+        var adapterDef = {
+          find: function(con, col, criteria, cb) {
+            return cb(null, [{number: Math.random() * 10000000000000000}]);
+          }
+        };
 
-      offshore.initialize({ adapters: { foobar: adapterDef }, connections: connections, cache: { prefix: 'test_cache_', defaultCacheTime: 100 } }, function(err, colls) {
-        if(err) return done(err);
-        query = colls.collections.random;
-        done();
-      });
-    });
+        var connections = {
+          'foo': {
+            adapter: 'foobar'
+          }
+        };
 
-    it('should cache results using user defined cacheKey and cacheTime', function(done) {
-      query.find({}).cache('cache_test', 10, function(err, first_values) {
-        assert(!err);
-        query.find({}).cache('cache_test', 10, function(err, cached_values) {
-          assert(!err);
-          assert(first_values[0].number === cached_values[0].number);
+        offshore.initialize({adapters: {foobar: adapterDef}, connections: connections, cache: {prefix: 'test_cache_', defaultCacheTime: 100}}, function(err, colls) {
+          if (err)
+            return done(err);
+          query = colls.collections.random;
           done();
         });
       });
-    });
 
-    it('should cache results using user defined cacheTime and automatic cacheKey', function(done) {
-      var criteria = { number: [1,2] };
-      query.find(criteria).cache(10, function(err, first_values) {
-        assert(!err);
-        query.find(criteria).cache(10, function(err, cached_values) {
-          assert(!err);
-          assert(first_values[0].number === cached_values[0].number);
-          done();
+      it('should cache results using user defined cacheKey and cacheTime', function(done) {
+        query.find({}).cache('cache_test', 10, function(err, first_values) {
+          assert(! err);
+          query.find({}).cache('cache_test', 10, function(err, cached_values) {
+            assert(! err);
+            assert(first_values[0].number === cached_values[0].number);
+            done();
+          });
+        });
+      });
+
+      it('should cache results using user defined cacheTime and automatic cacheKey', function(done) {
+        var criteria = {number: [1, 2]};
+        query.find(criteria).cache(10, function(err, first_values) {
+          assert(! err);
+          query.find(criteria).cache(10, function(err, cached_values) {
+            assert(! err);
+            assert(first_values[0].number === cached_values[0].number);
+            done();
+          });
+        });
+      });
+
+      it('should cache results with only a callback given', function(done) {
+        var criteria = {number: 100};
+        query.find(criteria).cache(function(err, first_values) {
+          assert(! err);
+          query.find(criteria).cache(function(err, cached_values) {
+            assert(! err);
+            assert(first_values[0].number === cached_values[0].number);
+            done();
+          });
         });
       });
     });
-    
-    it('should cache results with only a callback given', function(done) {
-      var criteria = { number: 100 };
-      query.find(criteria).cache(function(err, first_values) {
-        assert(!err);
-        query.find(criteria).cache(function(err, cached_values) {
-          assert(!err);
-          assert(first_values[0].number === cached_values[0].number);
+    describe('custom adapter cache', function() {
+      var query;
+
+      before(function(done) {
+
+        var offshore = new Offshore();
+        var Model = Offshore.Collection.extend({
+          identity: 'random',
+          connection: 'foo',
+          attributes: {
+            number: {
+              type: 'integer',
+              defaultsTo: 1
+            },
+            doSomething: function() {
+            }
+          }
+        });
+
+        offshore.loadCollection(Model);
+
+        // Fixture Adapter Def
+        var adapterDef = {
+          find: function(con, col, criteria, cb) {
+            return cb(null, [{number: Math.random() * 10000000000000000}]);
+          }
+        };
+
+        var connections = {
+          'foo': {
+            adapter: 'foobar'
+          }
+        };
+
+        offshore.initialize({adapters: {foobar: adapterDef}, connections: connections, cache: {prefix: 'test_cache_', defaultCacheTime: 100, adapter: require('offshore-memory')}}, function(err, colls) {
+          if (err)
+            return done(err);
+          query = colls.collections.random;
           done();
         });
       });
-    });
 
+      it('should cache results using user defined cacheKey and cacheTime', function(done) {
+        query.find({}).cache('cache_test', 10, function(err, first_values) {
+          assert(! err);
+          query.find({}).cache('cache_test', 10, function(err, cached_values) {
+            assert(! err);
+            assert(first_values[0].number === cached_values[0].number);
+            done();
+          });
+        });
+      });
+
+      it('should cache results using user defined cacheTime and automatic cacheKey', function(done) {
+        var criteria = {number: [1, 2]};
+        query.find(criteria).cache(10, function(err, first_values) {
+          assert(! err);
+          query.find(criteria).cache(10, function(err, cached_values) {
+            assert(! err);
+            assert(first_values[0].number === cached_values[0].number);
+            done();
+          });
+        });
+      });
+
+      it('should cache results with only a callback given', function(done) {
+        var criteria = {number: 100};
+        query.find(criteria).cache(function(err, first_values) {
+          assert(! err);
+          query.find(criteria).cache(function(err, cached_values) {
+            assert(! err);
+            assert(first_values[0].number === cached_values[0].number);
+            done();
+          });
+        });
+      });
+    });
   });
 });

--- a/test/unit/query/query.cache.js
+++ b/test/unit/query/query.cache.js
@@ -10,12 +10,12 @@ describe('Collection Query', function() {
 
       var offshore = new Offshore();
       var Model = Offshore.Collection.extend({
-        identity: 'user',
+        identity: 'random',
         connection: 'foo',
         attributes: {
-          name: {
-            type: 'string',
-            defaultsTo: 'Foo Bar'
+          number: {
+            type: 'integer',
+            defaultsTo: 1
           },
           doSomething: function() {}
         }
@@ -23,15 +23,10 @@ describe('Collection Query', function() {
 
       offshore.loadCollection(Model);
 
-      var first = true;
       // Fixture Adapter Def
       var adapterDef = { 
         find: function(con, col, criteria, cb) {
-          if (!first) {
-            return cb(new Error('should not call adapter.find a second time'));
-          }
-          first = false;
-          return cb(null, [{name: 'should be cached'}]);
+          return cb(null, [{number: Math.random() * 10000000000000000}]);
         }
       };
 
@@ -43,17 +38,41 @@ describe('Collection Query', function() {
 
       offshore.initialize({ adapters: { foobar: adapterDef }, connections: connections }, function(err, colls) {
         if(err) return done(err);
-        query = colls.collections.user;
+        query = colls.collections.random;
         done();
       });
     });
 
-    it('should cache results', function(done) {
-      query.find({}).cache('cache_test',10).exec(function(err, first_values) {
+    it('should cache results using user defined cacheKey and cacheTime', function(done) {
+      query.find({}).cache('cache_test', 10, function(err, first_values) {
         assert(!err);
-        query.find({}).cache('cache_test',10).exec(function(err, cached_values) {
+        query.find({}).cache('cache_test', 10, function(err, cached_values) {
           assert(!err);
-          assert(first_values[0].name === cached_values[0].name);
+          assert(first_values[0].number === cached_values[0].number);
+          done();
+        });
+      });
+    });
+
+    it('should cache results using user defined cacheTime and automatic cacheKey', function(done) {
+      var criteria = { number: [1,2] };
+      query.find(criteria).cache(10, function(err, first_values) {
+        assert(!err);
+        query.find(criteria).cache(10, function(err, cached_values) {
+          assert(!err);
+          assert(first_values[0].number === cached_values[0].number);
+          done();
+        });
+      });
+    });
+    
+    it('should cache results with only a callback given', function(done) {
+      var criteria = { number: 100 };
+      query.find(criteria).cache(function(err, first_values) {
+        assert(!err);
+        query.find(criteria).cache(function(err, cached_values) {
+          assert(!err);
+          assert(first_values[0].number === cached_values[0].number);
           done();
         });
       });

--- a/test/unit/query/query.cache.js
+++ b/test/unit/query/query.cache.js
@@ -36,7 +36,7 @@ describe('Collection Query', function() {
         }
       };
 
-      offshore.initialize({ adapters: { foobar: adapterDef }, connections: connections }, function(err, colls) {
+      offshore.initialize({ adapters: { foobar: adapterDef }, connections: connections, cache: { prefix: 'test_cache_', defaultCacheTime: 100 } }, function(err, colls) {
         if(err) return done(err);
         query = colls.collections.random;
         done();


### PR DESCRIPTION
# cache mechanism
##### configuration:

you can configure the cache by adding a `cache` object key in the offshore.initialize config object.
all options are optional.
###### options:

`adapter:` use a specific adapter ( ex: {adapter: require('offshore-memory')} ) 
`defaultCacheTime:` time in ms to keep cache if no `cacheTime` in query is specified
###### default adapter options:

`prefix:` the files prefix name.
`path:` a directory to place cache files
###### exemple:

``` javascript
    offshore.initialize({ cache: { prefix: 'test_cache_', defaultCacheTime: 100 }, ... 
```
##### usage:

add `cache` function to query:
    .cache(cacheKey, cacheTime, callback)
###### arguments:

`cacheKey:`  a developer defined unique key string for the query (optional)
`cacheTime:` the cache duration in ms (0 for unlimited, optional)
`callback:` a callback function

``` javascript
    // user defined cacheKey and cacheTime
    model.find(id).cache('model_find_' + id, 1800, function(err, model) { ... });

    // automatic cacheKey
    model.find(id).cache(1800, function(err, model) { ... });

    // automatic cacheKey and default cacheTime
    model.find(id).cache(function(err, model) { ... });
```
### todo
- [X] make developer defined string unique key (cacheKey) optional
- [X] pass cache options on offshore initialization
- [X] add ability to use configurable adapter for cache persistance
- [X] add more tests
- [X] [update doc](https://github.com/Atlantis-Software/offshore-docs/pull/3)
- [X] add a key/value pair interface spec in doc [datastore interface](https://github.com/Atlantis-Software/offshore-docs/pull/2)
- [X] implement datasore interface in offshore-memory
