### PR TITLE
add criteria on associations

### DIFF
--- a/lib/offshore/core/childValidations.js
+++ b/lib/offshore/core/childValidations.js
@@ -1,0 +1,39 @@
+var _ = require('lodash');
+var offshoreCriteria = require('offshore-criteria');
+
+var ChildValidator = module.exports = function(context) {
+  this.context = context;
+};
+
+ChildValidator.prototype.initialize = function(collectionName, criteria) {
+  this.collectionName = collectionName;
+  this.criteria = criteria;
+};
+
+ChildValidator.prototype.validate = function(values, presentOnly, cb) {
+  var self = this;
+  var errors = {};
+  // if true, defaults not already created ,creating it
+  if (!this.defaults) {
+    this.defaults = {};
+    if (this.criteria) {
+      _.keys(this.criteria).forEach(function(key) {
+        if (!self.context.offshore.collections[self.collectionName]._attributes[key])
+          return;
+        if (_.isObject(self.criteria[key]))
+          return;
+        self.defaults[key] = self.criteria[key];
+      });
+    }
+  }
+  values = _.defaults(values, this.defaults);
+
+  var result = offshoreCriteria([values], {where: this.criteria ? this.criteria.where : void 0}).results[0];
+  if (!result) {
+    errors.Criteria = [{rule: 'associationCriteria',
+        message: 'Child objects :\n' + require('util').inspect(values) + ' do not respect criteria specified in the collection.'}];
+    return cb(errors);
+  }
+  // calling model validation after validating association criteria
+  this.context.offshore.collections[this.collectionName]._validator.validate(values, presentOnly, cb);
+};

--- a/lib/offshore/core/index.js
+++ b/lib/offshore/core/index.js
@@ -33,7 +33,7 @@ var Core = module.exports = function(options) {
   // Construct our internal objects
   this._cast = new Cast();
   this._schema = new Schema(this);
-  this._validator = new Validator();
+  this._validator = new Validator(this);
 
   // Normalize attributes, extract instance methods, and callbacks
   // Note: this is ordered for a reason!
@@ -88,7 +88,7 @@ Core._initialize = function(options) {
   // Initialize internal objects from attributes
   this._schema.initialize(this._attributes, this.hasSchema, reservedAttributes);
   this._cast.initialize(this._schema.schema);
-  this._validator.initialize(_validations, this.types, this.defaults.validations);
+  this._validator.initialize(_validations, this.types, this.defaults.validations, this.offshore.schema[this.identity].criteria);
 
   // Set the collection's primaryKey attribute
   Object.keys(schemaAttributes).forEach(function(key) {

--- a/lib/offshore/core/validations.js
+++ b/lib/offshore/core/validations.js
@@ -12,6 +12,8 @@ var utils = require('../utils/helpers');
 var hasOwnProperty = utils.object.hasOwnProperty;
 var WLValidationError = require('../error/WLValidationError');
 
+var offshoreCriteria = require('offshore-criteria');
+var ChildValidator = require('./childValidations');
 
 /**
  * Build up validations using the Offshore-validator module.
@@ -19,8 +21,9 @@ var WLValidationError = require('../error/WLValidationError');
  * @param {String} adapter
  */
 
-var Validator = module.exports = function(adapter) {
+var Validator = module.exports = function(context) {
   this.validations = {};
+  this.context = context;
 };
 
 /**
@@ -51,18 +54,33 @@ var Validator = module.exports = function(adapter) {
  * }
  */
 
-Validator.prototype.initialize = function(attrs, types, defaults) {
+Validator.prototype.initialize = function(attrs, types, defaults, criteria) {
   var self = this;
 
   defaults = defaults || {};
 
   this.reservedProperties = ['defaultsTo', 'primaryKey', 'autoIncrement', 'unique', 'index', 'collection', 'dominant', 'through',
-          'columnName', 'foreignKey', 'references', 'on', 'groupKey', 'model', 'via', 'size',
+          'columnName', 'foreignKey', 'references', 'on', 'groupKey', 'model', 'via', 'size', 'criteria',
           'example', 'validationMessage', 'validations', 'populateSettings', 'onKey', 'protected'];
 
 
   if (defaults.ignoreProperties && Array.isArray(defaults.ignoreProperties)) {
     this.reservedProperties = this.reservedProperties.concat(defaults.ignoreProperties);
+  }
+
+  this.criteria = criteria;
+
+  this.defaults = {};
+  if (this.criteria) {
+    _.keys(this.criteria).forEach(function(key) {
+      if (!attrs[key]) {
+        return;
+      }
+      if (_.isObject(self.criteria[key])) {
+        return;
+      }
+      self.defaults[key] = self.criteria[key];
+    });
   }
 
   // add custom type definitions to validator
@@ -76,6 +94,14 @@ Validator.prototype.initialize = function(attrs, types, defaults) {
 
       // Ignore null values
       if (attrs[attr][prop] === null) return;
+
+      if (prop === 'collection' && attrs[attr].criteria) {
+        if (!self.childValidators) {
+          self.childValidators = {};
+        }
+        self.childValidators[attr] = new ChildValidator(self.context);
+        self.childValidators[attr].initialize(attrs[attr].collection, attrs[attr].criteria);
+      }
 
       // If property is reserved don't do anything with it
       if (self.reservedProperties.indexOf(prop) > -1) return;
@@ -205,6 +231,15 @@ Validator.prototype.validate = function(values, presentOnly, cb) {
 
   // Validate all validations in parallel
   async.each(validations, validate, function allValidationsChecked() {
+    //affecting default values specified in the model criteria to the record to insert if they don't exist
+    values = _.defaults(values, self.defaults);
+
+    var validated = offshoreCriteria([values], {where: self.criteria ? self.criteria.where : void 0}).results[0];
+    if (!validated) {
+      errors.Criteria = [{rule: 'modelCriteria',
+          message: 'Object :\n' + require('util').inspect(values) + ' does not respect criteria defined in the model.'}];
+    }
+
     if (Object.keys(errors).length === 0) return cb();
 
     cb(errors);

--- a/lib/offshore/model/lib/associationMethods/add.js
+++ b/lib/offshore/model/lib/associationMethods/add.js
@@ -72,7 +72,9 @@ Add.prototype.findPrimaryKey = function(attributes, values) {
   }
 
   // If no primary key check for an ID property
-  if (!primaryKey && hasOwnProperty(values, 'id')) primaryKey = 'id';
+  if (!primaryKey && hasOwnProperty(values, 'id')) {
+    primaryKey = 'id';
+  }
 
   return primaryKey;
 };
@@ -118,6 +120,12 @@ Add.prototype.createAssociations = function(key, records, cb) {
   var attribute = this.collection._attributes[key];
   var collectionName = attribute.collection.toLowerCase();
   var associatedCollection = this.collection.offshore.collections[collectionName];
+
+  if (this.collection._validator && this.collection._validator.childValidators && this.collection._validator.childValidators[key]) {
+    associatedCollection = _.extend(new associatedCollection.constructor(associatedCollection.offshore, associatedCollection.connections), associatedCollection);
+    associatedCollection._validator = this.collection._validator.childValidators[key];
+  }
+
   var relatedPK = _.find(associatedCollection.attributes, { primaryKey: true });
   var schema = this.collection.offshore.schema[this.collection.identity].attributes[key];
 

--- a/lib/offshore/query/deferred.js
+++ b/lib/offshore/query/deferred.js
@@ -13,6 +13,7 @@ var acyclicTraversal = require('../utils/acyclicTraversal');
 var hasOwnProperty = utils.object.hasOwnProperty;
 var async = require('async');
 var DeepCursor = require('./deepCursor');
+var mergeCriterias = require('../utils/mergeCriterias');
 
 // Alias "catch" as "fail", for backwards compatibility with projects
 // that were created using Q
@@ -244,6 +245,9 @@ Deferred.prototype.populate = function(keyName, criteria) {
 
       joins.push(join);
     }
+
+    // get the association default criteria
+    criteria = mergeCriterias(criteria, this._context.offshore.collections[this._context.identity]._attributes[keyName].criteria);
 
     // Append the criteria to the correct join if available
     if (criteria && joins.length > 1) {

--- a/lib/offshore/query/finders/basic.js
+++ b/lib/offshore/query/finders/basic.js
@@ -14,6 +14,7 @@ var offshoreCriteria = require('offshore-criteria');
 var _ = require('lodash');
 var async = require('async');
 var hasOwnProperty = utils.object.hasOwnProperty;
+var mergeCriterias = require('../../utils/mergeCriterias');
 
 module.exports = {
 
@@ -52,6 +53,8 @@ module.exports = {
 
     // Transform Search Criteria
     criteria = self._transformer.serialize(criteria);
+
+    criteria = mergeCriterias(criteria, this.offshore.schema[this.identity].criteria);
 
     // serialize populated object
     if (criteria.joins) {
@@ -256,6 +259,9 @@ module.exports = {
         }
       });
     }
+
+    // get the association default criteria
+    criteria = mergeCriterias(criteria, this.offshore.schema[this.identity].criteria);
 
     // Build up an operations set
     var operations = new Operations(self, criteria, 'find');

--- a/lib/offshore/utils/mergeCriterias.js
+++ b/lib/offshore/utils/mergeCriterias.js
@@ -1,0 +1,23 @@
+var _ = require('lodash');
+
+var merge = module.exports = function(destination, source) {
+  if (source) {
+    var userCriteria = _.cloneDeep(destination);
+    destination = _.merge({}, source, userCriteria);
+    // merging  the sort with _.defaults(), to ensure that userCriteria sort keys have more priority in order, and they should override same keys in the default sort
+    destination.sort = _.defaults({}, userCriteria.sort, source.sort);
+    // override "or" clause
+    if (userCriteria.where && userCriteria.where.or) {
+      destination.where.or = userCriteria.where.or;
+    }
+    else if (!userCriteria.where) {
+      destination.where = source.where;
+    }
+    // overriding select
+    if (userCriteria.select) {
+      destination.select = userCriteria.select;
+    }
+    return destination;
+  }
+  return destination;
+};

--- a/test/unit/utils/utils.mergeCriterias.js
+++ b/test/unit/utils/utils.mergeCriterias.js
@@ -1,0 +1,69 @@
+var _ = require('lodash');
+var assert = require('assert');
+var mergeCriterias = require('../../../lib/offshore/utils/mergeCriterias');
+
+describe('Criterias', function() {
+  describe('Where Clause', function() {
+    var source = {where: {
+        like: {attr1: 'val1', attr2: 'val2'},
+        or: [{attr3: 1}, {attr4: 2}],
+        contains: {attr5: 'con'},
+        array: [1, 2, 3],
+        attr6: {like: '%val6%'},
+        number: {'>': 0},
+        attr7: 'val7'
+      }
+    };
+    var destination = {where: {
+        like: {attr2: 'val22', attr3: 'val3'},
+        or: [{attr3: 3}, {attr10: 4}],
+        array: [4, 5],
+        attr6: {like: '%val66%'},
+        number: {'<': 10},
+        attr7: 'val10'
+      }
+    };
+    it('should be merged', function(done) {
+      var criteria = mergeCriterias(destination, source);
+      assert(criteria.where.like.attr1 === 'val1', 'key should be conserved if not exists in destination');
+      assert(criteria.where.like.attr2 === 'val22', 'key should be overriden if exists in destination');
+      assert(criteria.where.like.attr3 === 'val3', 'key should be added if not exists in source');
+      assert(criteria.where.or[0].attr3 === 3 && criteria.where.or[1].attr10 === 4, 'or should be overriden if exists in destination');
+      assert(criteria.where.array[0] === 4 && criteria.where.array[1] === 5, 'array should be overriden if exists in destination');
+      assert(criteria.where.attr6.like === '%val66%', 'inner like should be overriden');
+      assert(criteria.where.number['<'] === 10 && criteria.where.number['>'] === 0, 'number comparations should be merged');
+      assert(criteria.where.attr7 = 'val10', 'atributes should be overriden if specified in destination');
+      assert(criteria.where.contains, 'atributes should be conserved if not specified in destination');
+      done();
+    });
+  });
+  describe('Sort Clause', function() {
+    var source = {sort: {key1: 'asc', key2: 'asc'}};
+    var destination = {sort: {key3: 'desc', key2: 'desc'}};
+    it('should be merged', function(done) {
+      var criteria = mergeCriterias(destination, source);
+      assert(criteria.sort.key1 === 'asc', 'should conserve sort keys if not specified in destination');
+      assert(criteria.sort.key2 === 'desc', 'should override sort keys if specified in destination');
+      assert(criteria.sort.key3 === 'desc', 'should add new sort keys specified in destination');
+      assert(_.last(_.keys(criteria.sort)) === 'key1', 'default sort keys should have low priority in merged criteria');
+      done();
+    });
+
+  });
+
+  it('should override select and groupBy clauses', function(done) {
+    var source = {select: ['key1', 'key2'], groupBy: ['group1']};
+    var destination = {select: ['key3', 'key4'], groupBy: ['group2']};
+    var criteria = mergeCriterias(destination, source);
+    assert(criteria.select[0] === 'key3' && criteria.select[1] === 'key4' && criteria.groupBy[0] === 'group2');
+    done();
+  });
+
+  it('should overide limit and skip', function(done) {
+    var source = {limit: 1, skip: 1};
+    var destination = {limit: 2, skip: 2};
+    var criteria = mergeCriterias(destination, source);
+    assert(criteria.limit === 2 && criteria.skip === 2);
+    done();
+  });
+});

--- a/test/unit/validations/Validations.criterias.js
+++ b/test/unit/validations/Validations.criterias.js
@@ -1,0 +1,168 @@
+var Offshore = require('../../../lib/offshore');
+var assert = require('assert');
+var async = require('async');
+
+var offshore = new Offshore();
+var migrate = 'drop';
+
+describe('Criterias Valdiation', function() {
+  var AnimalModel, PersonModel, CloverModel;
+  before(function(done) {
+
+    var Person = Offshore.Collection.extend({
+      identity: 'Person',
+      connection: 'assoc_criterias',
+      tableName: 'person_table',
+      migrate: migrate,
+      attributes: {
+        "personId": {
+          "type": "integer",
+          "primaryKey": true
+        },
+        "personName": {
+          "type": "string"
+        },
+        sheeps: {
+          "collection": "Animal",
+          "via": "person",
+          criteria: {
+            where: {legsNumber: 4},
+            legsNumber: 4// default value
+          }
+        }
+      }
+    });
+
+    var Animal = Offshore.Collection.extend({
+      identity: 'Animal',
+      connection: 'assoc_criterias',
+      tableName: 'animal_table',
+      migrate: migrate,
+      attributes: {
+        "animalId": {
+          "type": "integer",
+          "primaryKey": true
+        },
+        "animalColor": {
+          "type": "string"
+        },
+        "legsNumber": {
+          "type": "integer"
+        },
+        person: {
+          "model": "person"
+        },
+        animalAge: {
+          "type": "integer"
+        }
+      }
+    });
+
+
+    var Clover = Offshore.Collection.extend({
+      identity: 'Clover',
+      connection: 'assoc_criterias',
+      tableName: 'clover_table',
+      migrate: migrate,
+      criteria: {
+        where: {"leafNumber": 3},
+        leafNumber: 3 // default value
+      },
+      attributes: {
+        "cloverId": {
+          "type": "integer",
+          "primaryKey": true
+        },
+        "cloverName": {
+          "type": "string"
+        },
+        leafNumber: {
+          "type": "integer"
+        }
+      }
+    });
+
+    offshore.loadCollection(Animal);
+    offshore.loadCollection(Person);
+    offshore.loadCollection(Clover);
+
+    var connections = {'assoc_criterias': {
+        adapter: 'adapter'}
+    };
+
+    offshore.initialize({adapters: {adapter: require('offshore-memory')}, connections: connections}, function(err, colls) {
+      if (err)
+        return done(err);
+      PersonModel = colls.collections.person;
+      AnimalModel = colls.collections.animal;
+      CloverModel = colls.collections.clover;
+      done();
+    });
+  });
+
+  it('should validate child record against association defined criteria', function(done) {
+    var marySheeps = [
+      {animalId: 1, animalColor: 'Black', legsNumber: 4, animalAge: 2},
+      {animalId: 2, animalColor: 'Cyan', legsNumber: 3, animalAge: 1}
+    ];
+
+    PersonModel.create({personId: 1, personName: 'Mary', sheeps: marySheeps}, function(err) {
+      assert(err, 'An error should be returned');
+      assert(err[0].values.legsNumber === 3, 'Error should contains the non valid child record');
+      done();
+    });
+  });
+
+  it('should validate record against model defined criteria', function(done) {
+    CloverModel.create({cloverId: 1, clovertName: 'clover', leafNumber: 4}).exec(function(err) {
+      assert(err, 'An error should be returned');
+      done();
+    });
+  });
+
+  it('should populate with children respecting association criteria and `.populate()` criteria', function(done) {
+    var sheeps = [
+      {animalId: 5, animalColor: 'Black', legsNumber: 3, animalAge: 0, person: 3},
+      {animalId: 6, animalColor: 'Cyan', legsNumber: 4, animalAge: 2, person: 3},
+      {animalId: 7, animalColor: 'Black', legsNumber: 4, animalAge: 1, person: 3}
+    ];
+
+    AnimalModel.createEach(sheeps, function(err) {
+      if (err)
+        return done(err);
+      PersonModel.create({personId: 3, personName: 'Samir'}).exec(function(err) {
+        if (err)
+          return done(err);
+        PersonModel.findOne(3).populate('sheeps', {where: {animalColor: 'Black', animalAge: {'<': 2}}})
+          .exec(function(err, person) {
+            if (err)
+              return done(err);
+            assert(person.sheeps.length === 1, 'Found children should respect the merged criterias');
+            assert(person.sheeps[0].animalColor === 'Black' && person.sheeps[0].animalAge === 1 && person.sheeps[0].legsNumber === 4,
+              'Found children should respect the merged criterias');
+            done();
+          });
+      });
+    });
+  });
+
+  it('should add default value specified in model criteria to attribute if resolved to undefined', function(done) {
+    CloverModel.create({cloverId: 2, clovertName: 'clover with default value'}).exec(function(err) {
+      assert(!err, 'Validation should succeed');
+      done();
+    });
+  });
+
+  it('should add default value specified in association criteria to attribute if resolved to undefined', function(done) {
+    var sheeps = [
+      {animalId: 8, animalColor: 'Red', animalAge: 2},
+      {animalId: 9, animalColor: 'Blue', animalAge: 3}
+    ];
+
+    PersonModel.create({personId: 4, personName: 'Jacques', sheeps: sheeps}, function(err) {
+      assert(!err, 'Validation should succeed');
+      done();
+    });
+  });
+
+});


### PR DESCRIPTION
### criteria

```
var User = Waterline.Collection.extend({
  identity: 'user',
  connection: 'local-postgresql',

  criteria : {
    sort: 'firstName ASC'
  }

  attributes: {
    firstName: 'string',
    lastName: 'string',
    dog: {
      collection: 'pet',
      via: 'owners',
      criteria : {
        where: {
          legs: 4
        }
      }
      dominant: true
    }
  }
});
```

all criteria passed in find,... or populate will be merged in model or association criteria : 
- in case of where in find: the where criterias are join with a AND operator
- in case of where in create: data will be validate before insert
- in case of sort: model or association criteria sort is the last sort order.
