### PR TITLE
add criteria to model and associations

### DIFF
--- a/lib/offshore/core/associationValidations.js
+++ b/lib/offshore/core/associationValidations.js
@@ -1,0 +1,43 @@
+var _ = require('lodash');
+var offshoreCriteria = require('offshore-criteria');
+var normalize = require('../utils/normalize');
+
+var AssociationValidator = module.exports = function(context) {
+  this.context = context;
+};
+
+AssociationValidator.prototype.initialize = function(collectionName, criteria) {
+  var self = this;
+  this.collectionName = collectionName;
+  this.criteria = normalize.criteria(criteria);
+  this.defaults = {};
+  if (this.criteria.where) {
+    _.keys(this.criteria.where).forEach(function(key) {
+      var attr = self.context.offshore.collections[self.collectionName]._attributes[key];
+      if (attr) {
+        var type = attr.type || attr;
+        var val = self.criteria.where[key];
+        if (_.isPlainObject(val) && type !== 'json') {
+          return;
+        }
+        if (_.isArray(val) && type !== 'array') {
+          return;
+        }
+        self.defaults[key] = val;
+      }
+    });
+  }
+};
+
+AssociationValidator.prototype.validate = function(values, presentOnly, cb) {
+  var errors = {};
+
+  values = _.defaults(values, this.defaults);
+
+  if (!offshoreCriteria([values], this.criteria).results[0]) {
+    errors.Association = [{rule: 'criteria', message: 'Associated objects :\n' + require('util').inspect(values) + ' do not respect criteria specified in the parent model.'}];
+    return cb(errors);
+  }
+  // calling model validation after validating association criteria
+  this.context.offshore.collections[this.collectionName]._validator.validate(values, presentOnly, cb);
+};

--- a/lib/offshore/core/index.js
+++ b/lib/offshore/core/index.js
@@ -33,7 +33,7 @@ var Core = module.exports = function(options) {
   // Construct our internal objects
   this._cast = new Cast();
   this._schema = new Schema(this);
-  this._validator = new Validator();
+  this._validator = new Validator(this);
 
   // Normalize attributes, extract instance methods, and callbacks
   // Note: this is ordered for a reason!
@@ -88,7 +88,7 @@ Core._initialize = function(options) {
   // Initialize internal objects from attributes
   this._schema.initialize(this._attributes, this.hasSchema, reservedAttributes);
   this._cast.initialize(this._schema.schema);
-  this._validator.initialize(_validations, this.types, this.defaults.validations);
+  this._validator.initialize(_validations, this.types, this.defaults.validations, this.offshore.schema[this.identity].criteria);
 
   // Set the collection's primaryKey attribute
   Object.keys(schemaAttributes).forEach(function(key) {

--- a/lib/offshore/core/validations.js
+++ b/lib/offshore/core/validations.js
@@ -11,7 +11,9 @@ var async = require('async');
 var utils = require('../utils/helpers');
 var hasOwnProperty = utils.object.hasOwnProperty;
 var WLValidationError = require('../error/WLValidationError');
-
+var offshoreCriteria = require('offshore-criteria');
+var associationValidator = require('./associationValidations');
+var normalize = require('../utils/normalize');
 
 /**
  * Build up validations using the Offshore-validator module.
@@ -19,8 +21,10 @@ var WLValidationError = require('../error/WLValidationError');
  * @param {String} adapter
  */
 
-var Validator = module.exports = function(adapter) {
+var Validator = module.exports = function(context) {
   this.validations = {};
+  this.associations = {};
+  this.context = context;
 };
 
 /**
@@ -51,18 +55,39 @@ var Validator = module.exports = function(adapter) {
  * }
  */
 
-Validator.prototype.initialize = function(attrs, types, defaults) {
+Validator.prototype.initialize = function(attrs, types, defaults, criteria) {
   var self = this;
 
   defaults = defaults || {};
 
   this.reservedProperties = ['defaultsTo', 'primaryKey', 'autoIncrement', 'unique', 'index', 'collection', 'dominant', 'through',
-          'columnName', 'foreignKey', 'references', 'on', 'groupKey', 'model', 'via', 'size',
+          'columnName', 'foreignKey', 'references', 'on', 'groupKey', 'model', 'via', 'size', 'criteria',
           'example', 'validationMessage', 'validations', 'populateSettings', 'onKey', 'protected'];
 
 
   if (defaults.ignoreProperties && Array.isArray(defaults.ignoreProperties)) {
     this.reservedProperties = this.reservedProperties.concat(defaults.ignoreProperties);
+  }
+
+  //this.criteria = criteria;
+  this.criteria = normalize.criteria(criteria);
+
+  this.defaults = {};
+
+  if (criteria) {
+    _.keys(this.criteria.where).forEach(function(key) {
+      if (attrs[key]) {
+        var type = attrs[key].type || attrs[key];
+        var val = self.criteria.where[key];
+        if (_.isPlainObject(val) && type !== 'json') {
+          return;
+        }
+        if (_.isArray(val) && type !== 'array') {
+          return;
+        }
+        self.defaults[key] = val;
+      }
+    });
   }
 
   // add custom type definitions to validator
@@ -76,6 +101,16 @@ Validator.prototype.initialize = function(attrs, types, defaults) {
 
       // Ignore null values
       if (attrs[attr][prop] === null) return;
+
+      if ((prop === 'collection') && attrs[attr].criteria) {
+        self.associations[attr] = new associationValidator(self.context);
+        self.associations[attr].initialize(attrs[attr].collection, attrs[attr].criteria);
+      }
+
+      if ((prop === 'model') && attrs[attr].criteria) {
+        self.associations[attr] = new associationValidator(self.context);
+        self.associations[attr].initialize(attrs[attr].model, attrs[attr].criteria);
+      }
 
       // If property is reserved don't do anything with it
       if (self.reservedProperties.indexOf(prop) > -1) return;
@@ -108,38 +143,40 @@ Validator.prototype.validate = function(values, presentOnly, cb) {
   var self = this;
   var errors = {};
   var validations = Object.keys(this.validations);
+  var associations = Object.keys(this.associations);
 
   // Handle optional second arg AND Use present values only, specified values, or all validations
-  /* eslint-disable no-fallthrough */
-  switch (typeof presentOnly) {
+  var type = Array.isArray(presentOnly) ? 'array' : typeof presentOnly;
+  
+  //affecting default values specified in the model criteria to the record to insert if they don't exist
+  values = _.defaults(values, self.defaults);
+  
+  switch (type) {
     case 'function':
       cb = presentOnly;
       break;
     case 'string':
       validations = [presentOnly];
       break;
-    case 'object':
-      if (Array.isArray(presentOnly)) {
-        validations = presentOnly;
-        break;
-      } // Fall through to the default if the object is not an array
+    case 'array':
+      validations = presentOnly;
+      break;
     default:
       // Any other truthy value.
       if (presentOnly) {
         validations = _.intersection(validations, Object.keys(values));
       }
-    /* eslint-enable no-fallthrough */
   }
 
   function validate(validation, cb) {
     var curValidation = self.validations[validation];
 
     // Build Requirements
-    var requirements = _.cloneDeep(validator(curValidation));
+    //var requirements = _.cloneDeep(validator(curValidation));
+    var requirements = validator(curValidation);
 
     // Grab value and set to null if undefined
-    var value = values[validation];
-    if (typeof value == 'undefined') value = null;
+    var value = _.isUndefined(values[validation]) ? null : values[validation];
 
     // If value is not required and empty then don't
     // try and validate it
@@ -149,7 +186,7 @@ Validator.prototype.validate = function(values, presentOnly, cb) {
 
     // If Boolean and required manually check
     if (curValidation.required && curValidation.type === 'boolean' && (typeof value !== 'undefined' && value !== null)) {
-      if (value.toString() == 'true' || value.toString() == 'false') return cb();
+      if (value.toString() === 'true' || value.toString() === 'false') return cb();
     }
 
     // If type is integer and the value matches a mongoID let it validate
@@ -204,10 +241,25 @@ Validator.prototype.validate = function(values, presentOnly, cb) {
   }
 
   // Validate all validations in parallel
-  async.each(validations, validate, function allValidationsChecked() {
-    if (Object.keys(errors).length === 0) return cb();
+  async.each(validations, validate, function() {
+    if (Object.keys(errors).length !== 0) {
+      return cb(errors);
+    }
+    // validate criteria of the model
+    if (!offshoreCriteria([values], {where: self.criteria ? self.criteria.where : void 0}).results[0]) {
+      errors.Criteria = [{rule: 'criteria', message: 'Object :\n' + require('util').inspect(values) + ' does not respect criteria defined in the model.'}];
+      return cb(errors);
+    }
+    // validate association's criteria
+    async.each(associations, function(association, cb) {
+      var associationValues = values[association] || [];
+      if (!_.isArray(associationValues)) {
+        associationValues = [associationValues];
+      }
+      async.each(associationValues, function(value, cb) {
+        self.associations[association].validate(value, false, cb);
+      },cb);
 
-    cb(errors);
+    }, cb);
   });
-
 };

--- a/lib/offshore/model/lib/associationMethods/add.js
+++ b/lib/offshore/model/lib/associationMethods/add.js
@@ -118,6 +118,12 @@ Add.prototype.createAssociations = function(key, records, cb) {
   var attribute = this.collection._attributes[key];
   var collectionName = attribute.collection.toLowerCase();
   var associatedCollection = this.collection.offshore.collections[collectionName];
+
+  if (this.collection._validator && this.collection._validator.associations[key]) {
+    associatedCollection = _.extend(new associatedCollection.constructor(associatedCollection.offshore, associatedCollection.connections), associatedCollection);
+    associatedCollection._validator = this.collection._validator.associations[key];
+  }
+
   var relatedPK = _.find(associatedCollection.attributes, { primaryKey: true });
   var schema = this.collection.offshore.schema[this.collection.identity].attributes[key];
 

--- a/lib/offshore/query/criteria.js
+++ b/lib/offshore/query/criteria.js
@@ -1,4 +1,5 @@
 var _ = require('lodash');
+var normalize = require('../utils/normalize');
 
 var Criteria = module.exports = {
   toString: function(criteria) {
@@ -33,5 +34,19 @@ var Criteria = module.exports = {
       });
       return ret.slice(0,-1) + '}';
     }
+  },
+  merge: function(destination, source) {
+    if (source) {
+      var dest = normalize.criteria(_.cloneDeep(destination));
+      source = normalize.criteria(source);
+      if (dest.where && source.where) {
+        destination.where = { and: [dest.where, source.where]};
+      } else if (dest.where || source.where) {
+        destination.where = dest.where || source.where;
+      }
+      destination.sort = _.defaults({}, dest.sort, source.sort);
+      return destination;
+    }
+    return destination;
   }
 };

--- a/lib/offshore/query/deferred.js
+++ b/lib/offshore/query/deferred.js
@@ -362,6 +362,9 @@ Deferred.prototype.populate = function(keyName, criteria) {
       joins.push(join);
     }
 
+    // get the association default criteria
+    criteria = Criteria.merge(criteria, this._context.offshore.collections[this._context.identity]._attributes[keyName].criteria);
+
     // Append the criteria to the correct join if available
     if (criteria && joins.length > 1) {
       joins[1].criteria = criteria;

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "switchback": "2.0.0",
     "prompt": "0.2.14",
     "offshore-criteria": "0.0.2",
-    "offshore-schema": "0.0.2"
+    "offshore-schema": "0.0.3"
   },
   "devDependencies": {
     "codeclimate-test-reporter": "0.3.1",

--- a/test/unit/model/criteria.js
+++ b/test/unit/model/criteria.js
@@ -1,0 +1,176 @@
+var Offshore = require('../../../lib/offshore');
+var assert = require('assert');
+var async = require('async');
+
+var offshore = new Offshore();
+var migrate = 'drop';
+
+describe('criteria', function() {
+  var AnimalModel, PersonModel, CloverModel;
+  before(function(done) {
+
+    var Person = Offshore.Collection.extend({
+      identity: 'Person',
+      connection: 'assoc_criterias',
+      tableName: 'person_table',
+      migrate: migrate,
+      attributes: {
+        "id": {
+          "type": "integer",
+          "primaryKey": true
+        },
+        "name": {
+          "type": "string"
+        },
+        sheeps: {
+          "collection": "Animal",
+          "via": "person",
+          criteria: {
+            legsCount: 4
+          }
+        }
+      }
+    });
+
+    var Animal = Offshore.Collection.extend({
+      identity: 'Animal',
+      connection: 'assoc_criterias',
+      tableName: 'animal_table',
+      migrate: migrate,
+      attributes: {
+        "id": {
+          "type": "integer",
+          "primaryKey": true
+        },
+        "color": {
+          "type": "string"
+        },
+        "legsCount": {
+          "type": "integer"
+        },
+        person: {
+          "model": "person"
+        },
+        age: {
+          "type": "integer"
+        }
+      }
+    });
+
+
+    var Clover = Offshore.Collection.extend({
+      identity: 'Clover',
+      connection: 'assoc_criterias',
+      tableName: 'clover_table',
+      migrate: migrate,
+      criteria: {
+        "leafCount": 3
+      },
+      attributes: {
+        "id": {
+          "type": "integer",
+          "primaryKey": true
+        },
+        "name": {
+          "type": "string"
+        },
+        leafCount: {
+          "type": "integer"
+        }
+      }
+    });
+
+    offshore.loadCollection(Animal);
+    offshore.loadCollection(Person);
+    offshore.loadCollection(Clover);
+
+    var connections = {'assoc_criterias': {
+        adapter: 'adapter'}
+    };
+
+    offshore.initialize({adapters: {adapter: require('offshore-memory')}, connections: connections}, function(err, colls) {
+      if (err) {
+        return done(err);
+      }
+      PersonModel = colls.collections.person;
+      AnimalModel = colls.collections.animal;
+      CloverModel = colls.collections.clover;
+      done();
+    });
+  });
+
+  it('should error if invalid association doesn\'t match model\'s association criteria', function(done) {
+    var marySheeps = [
+      {id: 1, color: 'White', legsCount: 4, age: 2},
+      {id: 2, color: 'Black', legsCount: 3, age: 1}
+    ];
+
+    PersonModel.create({id: 1, name: 'Mary', sheeps: marySheeps}, function(err) {
+      assert(err);
+      done();
+    });
+  });
+
+  it('should error if invalid value doesn\'t match model\'s criteria', function(done) {
+    CloverModel.create({id: 1, clovertName: 'clover', leafCount: 4}).exec(function(err) {
+      assert(err);
+      done();
+    });
+  });
+
+  it('should populate association matching model\'s association and query criterias', function(done) {
+    var animals = [
+      {id: 5, color: 'Black', legsCount: 3, age: 0, person: 3},
+      {id: 6, color: 'Cyan', legsCount: 4, age: 2, person: 3},
+      {id: 7, color: 'Black', legsCount: 4, age: 1, person: 3}
+    ];
+
+    AnimalModel.createEach(animals, function(err) {
+      if (err) {
+        return done(err);
+      }
+      PersonModel.create({id: 3, name: 'Samir'}).exec(function(err) {
+        if (err) {
+          return done(err);
+        }
+        PersonModel.findOne(3).populate('sheeps', {where: {color: 'Black', age: {'<': 2}}}).exec(function(err, person) {
+            if (err) {
+              return done(err);
+            }
+            assert(person.sheeps.length === 1);
+            assert(person.sheeps[0].color === 'Black');
+            assert(person.sheeps[0].age === 1);
+            assert(person.sheeps[0].legsCount === 4);
+            done();
+          });
+      });
+    });
+  });
+
+  it('should set model\'s criteria\'s defaults values when the value is undefined', function(done) {
+    CloverModel.create({id: 2}).exec(function(err, clover) {
+      assert.ifError(err);
+      assert(clover.leafCount === 3);
+      done();
+    });
+  });
+
+  it('should set association\'s criteria\'s defaults values when the value is undefined', function(done) {
+    var sheeps = [
+      {id: 8, color: 'Red', age: 2},
+      {id: 9, color: 'Blue', age: 3}
+    ];
+
+    PersonModel.create({id: 4, name: 'Jacques', sheeps: sheeps}, function(err) {
+      assert.ifError(err);
+      PersonModel.findOne(4).populate('sheeps').exec(function(err, person) {
+        assert.ifError(err);
+        assert(person.sheeps.length === 2);
+        assert(person.sheeps[0].legsCount === 4);
+        assert(person.sheeps[1].legsCount === 4);
+      });
+      done();
+    });
+  });
+
+});


### PR DESCRIPTION
### criteria

```
var User = Waterline.Collection.extend({
  identity: 'user',
  connection: 'local-postgresql',

  criteria : {
    sort: 'firstName ASC'
  }

  attributes: {
    firstName: 'string',
    lastName: 'string',
    dog: {
      collection: 'pet',
      via: 'owners',
      criteria : {
        legs: 4
      }
      dominant: true
    }
  }
});
```

all criteria passed in find,... or populate will be merged in model or association criteria : 
- in case of where in find: the where criterias are join with a AND operator
- in case of where in create: data will be validate before insert
- in case of sort: model or association criteria sort is the last sort order.

this require: https://github.com/Atlantis-Software/offshore-schema/pull/2
