### PR TITLE
type !== 'json' is not case sensitive

### DIFF
--- a/lib/offshore/core/transformations.js
+++ b/lib/offshore/core/transformations.js
@@ -135,7 +135,7 @@ Transformation.prototype.serialize = function(attributes, behavior) {
       if (_.isArray(obj[property]) && (property === 'or' || property === 'and')) return recursiveParse(obj[property], parentAttr);
 
       // If Nested Object check it's not a json attribute property
-      if (type !== 'json' && _.isPlainObject(obj[property])) {
+      if (type && type.toLowerCase() !== 'json' && _.isPlainObject(obj[property])) {
 
         // check if object key is in the transformations
         if (hasOwnProperty(self._transformations, property)) {


### PR DESCRIPTION
Support for models who's attribute types are 'JSON'
